### PR TITLE
Edit regex pattern into inverse form to handle non ASCII characters

### DIFF
--- a/lua/easyread/init.lua
+++ b/lua/easyread/init.lua
@@ -58,7 +58,7 @@ M.highlight = function()
         end
 
         -- highlight according to hlValues
-        for s, w in string.gmatch(line, '()(%w+)') do
+        for s, w in string.gmatch(line, '()([^%s%p%d]+)') do
             -- reset saccadecounter if over the interval
             if saccadecounter > M.config.saccadeInterval then
                 saccadecounter = 0


### PR DESCRIPTION
If there is a non-ASCII character in the word, the lua regex takes it as a word separator. This results in not highlighting the non-ASCII character and highlighting the letters after that character in the middle of the word.

I hope I haven't left out some corner case.